### PR TITLE
Remove deprecated git:// from pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.27.0
     hooks:
       - id: terraform_fmt


### PR DESCRIPTION
# Purpose

Github deprecated their use of the insecure git:// protocol and this will now result in a pre-commit timing out. This PR updates it to use https://

## Approach

_Explain how your code addresses the purpose of the change._

## Learning

https://blog.readthedocs.com/github-git-protocol-deprecation/

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
